### PR TITLE
Specifies that this is a JS/TS project

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,18 @@
+public/* linguist-vendored
+
+# Enforce Unix newlines
+*.css   text eol=lf
+*.html  text eol=lf
+*.js    text eol=lf
+*.json  text eol=lf
+*.md    text eol=lf
+*.scss  text eol=lf
+*.svg   text eol=lf
+*.txt   text eol=lf
+*.xml   text eol=lf
+*.xml.* text eol=lf
+*.yml   text eol=lf
+*.ts	text eol=lf
+
+# Don't diff or textually merge source maps
+*.map   binary


### PR DESCRIPTION
The project was considered as a css project. the addition of this attribute allows to recognize it as a Js/ts project